### PR TITLE
Move per-profile delay outside post loop

### DIFF
--- a/Python_grabber.py
+++ b/Python_grabber.py
@@ -38,9 +38,9 @@ def scrape_profiles():
             if len(posts_data) >= 3: # Example: limit to 3 post per profile for testing
                 break
 
-                
+
             if post.date >= cutoff_date:
-                    if post.date > last_timestamp: 
+                    if post.date > last_timestamp:
                         try:
                             location = post.location.name if post.location else "Unknown"
                         except KeyError:
@@ -60,13 +60,13 @@ def scrape_profiles():
                     # Save the timestamp of the latest post processed
                     with open(timestamp_file, "w") as file:
                         file.write(post.date.isoformat())
-        
-            # Sleep between profiles to avoid rate limiting
-            time.sleep(60)
-            
-        # Write posts data to a JSON file for later use in mapping 
+
+        # Write posts data to a JSON file for later use in mapping
         with open('posts_data.json', 'w') as json_file:
             json.dump(posts_data, json_file, indent=4)
+
+        # Sleep between profiles to avoid rate limiting
+        time.sleep(60)
 
 # Run the scraping function right now 
 scrape_profiles()


### PR DESCRIPTION
## Summary
- Pause for 60 seconds after processing each profile instead of after every post

## Testing
- `python -m py_compile Python_grabber.py`


------
https://chatgpt.com/codex/tasks/task_e_689978d34ba4833297bf8227cda599a4